### PR TITLE
Update lodash dependency and simplify template naming in loader

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -1,5 +1,0 @@
-module.exports.toCamelCase = function(input) { 
-    return input.toLowerCase().replace(/-(.)/g, function(match, group1) {
-        return group1.toUpperCase();
-    });
-}

--- a/lib/templateloader.js
+++ b/lib/templateloader.js
@@ -1,6 +1,6 @@
 var path = require('path'),
 		glob = require('glob'),
-    common = require('./common');
+	_ = require('lodash');
 
 function parseElement(el){	
 	el.fill = el.fill || " ";
@@ -36,14 +36,7 @@ module.exports.load = function(specPath){
 			specs = glob.sync(specPath + "/**/*.tpl.js");
 
 	specs.forEach(function (file) {
-	  var name  = common.toCamelCase(path.basename(file).replace('.tpl.js',''));
-
-	  if (~file.indexOf('-')) {
-	    name = file
-	    .split('-').map(function (part) {
-	      return capitalize(part);
-	    }).join('');
-	  }
+	  var name  = _.camelCase(path.basename(file).replace('.tpl.js',''));
 
 	  ret[name] = loadSpec(file);
   });  

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "mocha": "~1.14.0"
   },
   "dependencies": {
-    "lodash": "~2.2.1",
+    "lodash": "~3.0.0",
     "glob": "~3.2.6"
   }
 }


### PR DESCRIPTION
Updated lodash dependency to ~3.0.0, to access their version of _.camelCase in the templateloader.

Removed common.js, with the custom implementation of toCamelCase()

From lodash...
    /**
     \* Converts `string` to [camel case](https://en.wikipedia.org/wiki/CamelCase).
     *
     \* @static
     \* @memberOf _
     \* @category String
     \* @param {string} [string=''] The string to convert.
     \* @returns {string} Returns the camel cased string.
     \* @example
     *
     \* _.camelCase('Foo Bar');
     \* // => 'fooBar'
     *
     \* _.camelCase('--foo-bar');
     \* // => 'fooBar'
     *
     \* _.camelCase('__foo_bar__');
     \* // => 'fooBar'
     */
    var camelCase = createCompounder(function(result, word, index) {
      word = word.toLowerCase();
      return result + (index ? (word.charAt(0).toUpperCase() + word.slice(1)) : word);
    });
